### PR TITLE
Df15 : Gestion des nouveaux états côté front

### DIFF
--- a/shoploc-pa/src/app/components/commande-list-element/commande-list-element.component.ts
+++ b/shoploc-pa/src/app/components/commande-list-element/commande-list-element.component.ts
@@ -34,9 +34,14 @@ export class CommandeListElementComponent implements OnInit {
         this.etatAffiche = 'En attente de validation';
         break;
       }
-      case 'EN_ATTENTE_DE_PAIEMENT' : {
+      case 'EN_ATTENTE_DE_PAIEMENT_DIRECT' : {
         this.color = '#dbd000';
-        this.etatAffiche = 'En attente de paiement';
+        this.etatAffiche = 'En attente de paiement chez votre commerçant';
+        break;
+      }
+      case 'EN_ATTENTE_DE_PAIEMENT_SHOPLOC' : {
+        this.color = '#dbd000';
+        this.etatAffiche = 'En attente de paiement sur l\'application shoploc';
         break;
       }
       case 'EN_PREPARATION' : {

--- a/shoploc-pa/src/app/components/commande-list/commande-list.component.ts
+++ b/shoploc-pa/src/app/components/commande-list/commande-list.component.ts
@@ -58,7 +58,7 @@ export class CommandeListComponent implements OnInit {
     if(commande.etat == 'EN_ATTENTE_DE_PAIEMENT'){
       this.router.navigate(['paiement-commande-client'],{queryParams: { commande : commande.cid }});
     }
-    if(commande.etat == 'EN_PREPARATION'){
+    if(commande.etat == 'EN_PREPARATION' || commande.etat == 'A_RECUPERER'){
       this.router.navigate(['qrcode-commande'],{queryParams: { commande : commande.cid }});
     }
   }

--- a/shoploc-pa/src/app/components/commande-list/commande-list.component.ts
+++ b/shoploc-pa/src/app/components/commande-list/commande-list.component.ts
@@ -55,10 +55,10 @@ export class CommandeListComponent implements OnInit {
     if(commande.etat == 'PANNIER'){
       this.router.navigate(['creation-commande-client'],{queryParams: { commercant: commande.commercant, commande : commande.cid }});
     }
-    if(commande.etat == 'EN_ATTENTE_DE_PAIEMENT'){
+    if(commande.etat == 'EN_ATTENTE_DE_PAIEMENT_SHOPLOC'){
       this.router.navigate(['paiement-commande-client'],{queryParams: { commande : commande.cid }});
     }
-    if(commande.etat == 'EN_PREPARATION' || commande.etat == 'A_RECUPERER'){
+    if(commande.etat == 'EN_PREPARATION' || commande.etat == 'A_RECUPERER' || commande.etat == 'EN_ATTENTE_DE_PAIEMENT_DIRECT'){
       this.router.navigate(['qrcode-commande'],{queryParams: { commande : commande.cid }});
     }
   }

--- a/shoploc-pa/src/app/components/commercant-commande-list-element/commercant-commande-list-element.component.ts
+++ b/shoploc-pa/src/app/components/commercant-commande-list-element/commercant-commande-list-element.component.ts
@@ -27,9 +27,9 @@ export class CommercantCommandeListElementComponent implements OnInit {
     this.clicked=false;
     this.dateAffiche = this.datePipe.transform(this.date,'dd/MM/yyyy HH:mm');
     switch(this.etat){
-      case 'EN_ATTENTE_DE_PAIEMENT' : {
+      case 'EN_ATTENTE_DE_PAIEMENT_DIRECT' : {
         this.color = '#dbd000';
-        this.etatAffiche = 'En attente de paiement';
+        this.etatAffiche = 'En attente de paiement en direct';
         break;
       }
       case 'EN_PREPARATION' : {

--- a/shoploc-pa/src/app/components/commercant-detail-commande/commercant-detail-commande.component.html
+++ b/shoploc-pa/src/app/components/commercant-detail-commande/commercant-detail-commande.component.html
@@ -33,6 +33,9 @@
             <div *ngIf="commande.etat == 'A_RECUPERER'" >
                 <button type="button" class="btn btn-success position-valider" (click)="laCommandeEstRecuperee()">La commande est récupérée</button>
             </div>
+            <div *ngIf="commande.etat == 'EN_ATTENTE_DE_PAIEMENT_DIRECT'" >
+                <button type="button" class="btn btn-success position-valider" (click)="laCommandeEstRecuperee()">La commande est payée et récupérée</button>
+            </div>
             <div *ngIf="commande.etat == 'RECUPEREE'" class="mt-5">
                 <div class="row justify-content-center d-flex">
                     <mat-icon class="icon-display">

--- a/shoploc-pa/src/app/components/commercant-home/commercant-home.component.ts
+++ b/shoploc-pa/src/app/components/commercant-home/commercant-home.component.ts
@@ -67,7 +67,7 @@ export class CommercantHomeComponent implements OnInit {
 
   getWaitPaiement() {
     this.listeCommandeWaitPaiement = [];
-    this.commandeService.getCommandeByEtatAndCommercant(this.username, 'EN_ATTENTE_DE_PAIEMENT').subscribe(res => {
+    this.commandeService.getCommandeByEtatAndCommercant(this.username, 'EN_ATTENTE_DE_PAIEMENT_DIRECT').subscribe(res => {
       for(let commande of res){
         this.listeCommandeWaitPaiement.push(commande);
       }

--- a/shoploc-pa/src/app/components/creation-commande-client/creation-commande-client.component.ts
+++ b/shoploc-pa/src/app/components/creation-commande-client/creation-commande-client.component.ts
@@ -166,7 +166,7 @@ export class CreationCommandeClientComponent implements OnInit {
   }
 
   validerCommandePaiementEnDirect(){
-    this.commandeService.confirmCommande(this.commande.cid).subscribe(response => {
+    this.commandeService.confirmCommandeDirect(this.commande.cid).subscribe(response => {
       this.showModal = false;
       this.router.navigate(['commande-list']);
     })
@@ -176,7 +176,7 @@ export class CreationCommandeClientComponent implements OnInit {
     let usernameClient = this.authService.currentUserValue.username;
     this.porteMonnaieService.getSoldeFidelite(usernameClient).subscribe(mapSolde => {
       if(this.commande.totalPointsFidelite <= mapSolde["soldeFidelite"]){
-        this.commandeService.confirmCommande(this.commande.cid).subscribe(response => {
+        this.commandeService.confirmCommandeShoploc(this.commande.cid).subscribe(response => {
           this.showModal = false;
           this.router.navigate(['paiement-commande-client'],{queryParams: { commande : response.cid }});
         },(err: HttpErrorResponse) => {

--- a/shoploc-pa/src/app/components/creation-commande-client/creation-commande-client.component.ts
+++ b/shoploc-pa/src/app/components/creation-commande-client/creation-commande-client.component.ts
@@ -179,6 +179,12 @@ export class CreationCommandeClientComponent implements OnInit {
         this.commandeService.confirmCommande(this.commande.cid).subscribe(response => {
           this.showModal = false;
           this.router.navigate(['paiement-commande-client'],{queryParams: { commande : response.cid }});
+        },(err: HttpErrorResponse) => {
+          if (err.status === 404) {
+            this.showModal = false;
+            this.messageError = "Votre commande est vide ! ";
+            this.showError = true;
+          }
         });
       }else{
         this.showModal = false;

--- a/shoploc-pa/src/app/components/creation-commande-client/creation-commande-client.component.ts
+++ b/shoploc-pa/src/app/components/creation-commande-client/creation-commande-client.component.ts
@@ -175,7 +175,7 @@ export class CreationCommandeClientComponent implements OnInit {
   validerCommandePaiementShopLoc(){
     let usernameClient = this.authService.currentUserValue.username;
     this.porteMonnaieService.getSoldeFidelite(usernameClient).subscribe(mapSolde => {
-      if(this.commande.totalPointsFidelite < mapSolde["soldeFidelite"]){
+      if(this.commande.totalPointsFidelite <= mapSolde["soldeFidelite"]){
         this.commandeService.confirmCommande(this.commande.cid).subscribe(response => {
           this.showModal = false;
           this.router.navigate(['paiement-commande-client'],{queryParams: { commande : response.cid }});

--- a/shoploc-pa/src/app/components/qrcode-commande/qrcode-commande.component.html
+++ b/shoploc-pa/src/app/components/qrcode-commande/qrcode-commande.component.html
@@ -7,7 +7,8 @@
                 </button>
             </div>
             <div class="col-10 float-left">
-                <p class="mb-0 h4 text-align-left pb-0 pt-1 float-left">Commande {{commande.cid}}</p>
+                <p ngIf="isReady" class="mb-0 h4 text-align-left pb-0 pt-1 float-left">Commande {{commande.cid}}</p>
+                <p ngIf="!isReady" class="mb-0 h4 text-align-left pb-0 pt-1 float-left">Commande</p>
             </div>
         </div>
     </div> 

--- a/shoploc-pa/src/app/components/qrcode-commande/qrcode-commande.component.html
+++ b/shoploc-pa/src/app/components/qrcode-commande/qrcode-commande.component.html
@@ -7,8 +7,12 @@
                 </button>
             </div>
             <div class="col-10 float-left">
-                <p ngIf="isReady" class="mb-0 h4 text-align-left pb-0 pt-1 float-left">Commande {{commande.cid}}</p>
-                <p ngIf="!isReady" class="mb-0 h4 text-align-left pb-0 pt-1 float-left">Commande</p>
+                <div *ngIf="isReady">
+                    <p class="mb-0 h4 text-align-left pb-0 pt-1 float-left">Commande {{commande.cid}}</p>
+                </div>
+                <div *ngIf="!isReady">
+                    <p class="mb-0 h4 text-align-left pb-0 pt-1 float-left">Commande</p>
+                </div>
             </div>
         </div>
     </div> 

--- a/shoploc-pa/src/app/components/qrcode-commande/qrcode-commande.component.ts
+++ b/shoploc-pa/src/app/components/qrcode-commande/qrcode-commande.component.ts
@@ -30,8 +30,8 @@ export class QrcodeCommandeComponent implements OnInit {
     this.showModal = false;
     this.generated = false;
     this.activateRoute.queryParams.subscribe(params => {
-      this.commandeService.getCommande(Number(params['commande'])).subscribe(commande => {
-        this.commande = commande;
+      this.commandeService.getCommande(Number(params['commande'])).subscribe(commandeResponse => {
+        this.commande = commandeResponse;
         this.qrValue = 'COMMANDE;'.concat(this.commande.cid.toString());
         this.commandeService.getCommandeContenu(this.commande.cid).subscribe(response => {
           this.contenuCommande = response;

--- a/shoploc-pa/src/app/services/commande.service.ts
+++ b/shoploc-pa/src/app/services/commande.service.ts
@@ -63,12 +63,23 @@ export class CommandeService {
     }
 
     /**
-     * Confirme une commande et passe son état à "EN ATTENTE DE PAIEMENT"
+     * Confirme une commande et passe son état à "EN ATTENTE DE PAIEMENT SHOPLOC"
      * @param commandeId : number
      */
-    confirmCommande(commandeId : number) : Observable<CommandeResponseBody>{
+    confirmCommandeShoploc(commandeId : number) : Observable<CommandeResponseBody>{
         const url = environment.shopLocApiURL
-            .concat("/commande/confirmCommande/")
+            .concat("/commande/confirmCommandeShoploc/")
+            .concat(commandeId.toString());
+        return this.http.post<CommandeResponseBody>(url,null);
+    }
+
+     /**
+     * Confirme une commande et passe son état à "EN ATTENTE DE PAIEMENT DIRECT"
+     * @param commandeId : number
+     */
+    confirmCommandeDirect(commandeId : number) : Observable<CommandeResponseBody>{
+        const url = environment.shopLocApiURL
+            .concat("/commande/confirmCommandeDirect/")
             .concat(commandeId.toString());
         return this.http.post<CommandeResponseBody>(url,null);
     }


### PR DESCRIPTION
L'état "en attente de paiement" a été divisé en deux états "en attente de paiement direct" et "en attente de paiement shoploc".
### Conséquences côté client : 
* Une commande "en attente de paiement shoploc" redirige vers l'écran de paiement en ligne
* Une commande "en attente de paiement direct" redirige vers l'écran "qrcode" de la commande, ce qrcode devra être scanné par le commerçant au moement du paiement.
### Conséquences côté commerçant :
*  Dans le board des commandes du commerçants, on voit dans l'onget "en attente de paiement" uniquement les commandes "en attente de paiement direct"
* Dans le détail d'une commande "en attente de paiement direct" on un bouton qui permet de valider le paiement et de valider la récupération d'un coup, on passe de l'état "en attente de paiement direct" à "récupérée"